### PR TITLE
Added option field for custom nim arguments

### DIFF
--- a/lib/compiler.coffee
+++ b/lib/compiler.coffee
@@ -10,7 +10,7 @@ KnownFiles = require './known-files'
 class Compiler
   constructor: (@options) ->
     @trackedTemp = temp.track()
-    tempFile = @trackedTemp.openSync 
+    tempFile = @trackedTemp.openSync
       prefix: 'nimcheck'
       suffix: '.nim'
     @tempFilePath = tempFile.path
@@ -18,6 +18,8 @@ class Compiler
 
   check: (filePath, cb) ->
     args = ["check", "--listFullPaths", "--colors:off", "--verbosity:0"]
+    for arg in @options.nimCustomArgs
+      args.push arg
     if @options.nimLibPath.length
       args.push "--lib:\"#{@options.nimLibPath}\""
     args.push filePath
@@ -26,6 +28,8 @@ class Compiler
   checkDirty: (rootFilePath, filePath, fileText, cb) ->
     trackArg = "--trackDirty:#{@tempFilePath},#{filePath},1,1"
     args = ["check", "--listFullPaths", "--colors:off", "--verbosity:0", trackArg]
+    for arg in @options.nimCustomArgs
+      args.push arg
     if @options.nimLibPath.length
       args.push "--lib:\"#{@options.nimLibPath}\""
     args.push rootFilePath

--- a/lib/config.coffee
+++ b/lib/config.coffee
@@ -17,35 +17,41 @@ module.exports =
     description: 'Full path to the nim standard library (ex: c:\\nim\\lib).  This is optional, only use this if nim or nimsuggest cannot find system.nim.'
     order: 3
 
+  nimCustomArguments:
+    type: 'string'
+    default: ''
+    description: 'Custom arguments to pass to nim (ex: --threads:on)'
+    order: 4
+
   nimsuggestEnabled:
     type: 'boolean'
     default: false
     description: 'Use nimsuggest server to speed up autocomplete and jump to definition.  Only available when opening a folder where one of the Project Filenames (see below) is found.'
-    order: 4
+    order: 5
 
   onTheFlyChecking:
     type: 'boolean'
     default: false
     description: 'Enables live file-level eror checking.  If this is disabled, files will only be checked for errors on save.  You must restart Atom for this to take effect.'
-    order: 5
+    order: 6
 
   autocomplete:
     type: 'string'
     default: 'Always'
     enum: ['Always', 'Only after dot', 'Never']
-    order: 6
+    order: 7
 
   useCtrlShiftClickToJumpToDefinition:
     type: 'boolean'
     default: true
     description: 'If this is disabled, alt-g can also be used, but it is slow for some reason.'
-    order: 7
+    order: 8
 
   autosaveBeforeBuild:
     type: 'string'
     default: 'Save all files'
     enum: ['Save all files', 'Save current file', "Don't save any files"]
-    order: 8
+    order: 9
 
   runCommand:
     type: 'string'
@@ -54,7 +60,7 @@ module.exports =
       Note that it executes the command as a child process, which doesn't have a terminal window unless you open one explicity in the command.  Examples (type the correct one into the box below):<br/><br/>
       <b>No terminal window, any platform:</b> <code>&lt;bin&gt;</code><br/>
       <b>Windows w/ terminal:</b> <code>start &lt;bin&gt;</code><br/>
-      <b>OSX w/ terminal:</b> <code>open -a Terminal "&#96;&lt;bin&gt;&#96;"</code><br/> 
+      <b>OSX w/ terminal:</b> <code>open -a Terminal "&#96;&lt;bin&gt;&#96;"</code><br/>
       <b>Linux w/ terminal (gnome):</b> <code>gnome-terminal -e "&lt;bin&gt;"</code><br/>
       """
-    order: 9
+    order: 10


### PR DESCRIPTION
A simple implementation of adding a configuration field for custom arguments. Closes #12 

The implementation isn't perfect, because it simply splits the configuration string on whitespace to separate the individual arguments. I.e., it would fail on `--passL:"some arg with spaces"`. Fortunately, the most frequent arguments do not have spaces.

Note: This is the first time I'm writing coffeescript / hacking in Atom, so a closer look to the pull request would be appreciated.