### PR TITLE
Updated nimble-info.coffee fixing crash

### DIFF
--- a/lib/nimble-info.coffee
+++ b/lib/nimble-info.coffee
@@ -29,7 +29,7 @@ getNimbleDict = (folderPath) ->
 
 class NimbleInfo
   constructor: (@folderPath) ->
-    [@data, @nimbleFilePath] = getNimbleDict folderPath
+    [@data, @nimbleFilePath] = getNimbleDict @folderPath
     @hasNimbleFile = @data?
     @srcDir = path.join(@folderPath, @getFirst('srcDir') || '')
     @binDir = path.join(@folderPath, @getFirst('binDir') || '')


### PR DESCRIPTION
The file contained a typo (folderPath instead of @folderPath) which made the plugin unusable.